### PR TITLE
Improve default zooming

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,7 @@ github_project: smortex/map
 baseurl: "" # the subpath of your site, e.g. /map
 url: "https://smortex.github.io/map" # the base hostname & protocol for your site, e.g. https://example.com
 thunderforest_apikey: "f001bec5e17447b0b597e5a8e766bbf2" # the Thunderforest API key for map tiles
+min_users_for_local_map: 5 # With that many users or more, bound the map to them, otherwise display the whole earth
 
 # Build settings
 markdown: kramdown

--- a/index.md
+++ b/index.md
@@ -67,7 +67,11 @@ function callback(data) {
 
     L.control.scale({maxWidth: 300}).addTo(map);
 
-    map.fitWorld();
+    if (data.length >= {{ site.min_users_for_local_map }}) {
+        map.fitBounds(L.latLngBounds(members.map(e => e.getLatLng())));
+    } else {
+        map.fitWorld();
+    }
 }
 
 fetch("{{ site.url }}/data.json")


### PR DESCRIPTION
When we have bunch of users, we want the default zoom to allow to see
all of them, but when we do not have many users, the zoom is generaly
not appropriate.

Add a configuration setting to allow to choose when fitting the world is
preferred to fitting to the locations of all users.
