### PR TITLE
Always run action on the gh-pages branch

### DIFF
--- a/.github/workflows/add_me_to_the_map.yml
+++ b/.github/workflows/add_me_to_the_map.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          ref: 'gh-pages'
       - name: Add user location
         run: |
           ./.github/actions/add-user-location ${{ github.triggering_actor }}

--- a/.github/workflows/remove_me_from_the_map.yml
+++ b/.github/workflows/remove_me_from_the_map.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          ref: 'gh-pages'
       - name: Remove user location
         run: |
          rm -f _data/${{ github.triggering_actor }}.json


### PR DESCRIPTION
This branch has the actual data. It should be the default branches of
forked repositories, but the main repo will use the main branch for that
purpose.  With this, we should not have data pushed to the wrong
location.

While here remove fetch-depth as 0 means fetch everything and the
default is more sensible.
