### PR TITLE
Allow to use a local bundle in the `vendor` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Gemfile.lock
 _site
+vendor

--- a/_config.yml
+++ b/_config.yml
@@ -16,3 +16,4 @@ exclude:
   - Gemfile.lock
   - LICENSE
   - README.md
+  - vendor


### PR DESCRIPTION
This makes it easier to run locally.

This ignores the /vendor directory so `bundle exec` works when installed  there. It also allows the `data.json` file to load from localhost.

Run with `bundle exec jekyll serve --config "_config.yml,_config_dev.yml"`

And if there's a better way to specify config options per environment, I'd love to know it!
