### PR TITLE
First pass at local "about" content

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,27 @@ This will allow you to sync updates and fixes submitted upstream in your fork ea
 1. Collect and setup the required API keys (see bellow);
 1. Make sure your community members are allowed to trigger GitHub actions in your repository so that they can add their location to the map in self-service mode.
 
+### Adding local "about" context
+
+If you would like to add more information about your local instance, such as which
+github teams have write permissions to the repo or contact information for the admins,
+then create markdown files in the `_about` directory. The files must have front matter
+and if you specify a `title` attribute, then it will be displayed as a heading.
+
+```
+---
+title: This will be the heading
+---
+Put any markdown content you'd like here.
+It will render as expected.
+```
+
+```
+---
+---
+This option, with empty front matter, will use the filename as a heading.
+```
+
 ### Syncing your fork
 
 1. Synchronize the `main` branch of your fork with the upsteam repository;

--- a/_config.yml
+++ b/_config.yml
@@ -17,3 +17,7 @@ exclude:
   - LICENSE
   - README.md
   - vendor
+
+collections:
+  about:
+    output: false

--- a/about.md
+++ b/about.md
@@ -34,3 +34,10 @@ Check `.github/actions/aggregate-members-location/action.yml` to see how it's do
 
 [Add me to the map]:https://github.com/{{ site.github_project }}/actions/workflows/add_me_to_the_map.yml
 [Remove me from the map]:https://github.com/{{ site.github_project }}/actions/workflows/remove_me_from_the_map.yml
+
+<div class="localcontext">
+  {% for about in site.about %}
+    {% if about.title %}<h2>{{ about.title }}</h2>{% endif %}
+    {{ about.content | markdownify }}
+  {% endfor %}
+</div>


### PR DESCRIPTION
This lets local installations add content to their /about pages without
causing git merge conflicts when they update from upstream later on.
