### PR TITLE
Sort the order of entries in data.json

### DIFF
--- a/.github/actions/aggregate-members-location/action.yml
+++ b/.github/actions/aggregate-members-location/action.yml
@@ -7,4 +7,4 @@ runs:
   - name: Aggregate members location
     shell: bash
     run: |
-      find _data -name \*.json | xargs cat | jq -s > data.json
+      find _data -name \*.json | sort | xargs cat | jq -s > data.json


### PR DESCRIPTION
When aggregating data, find(1) will list files in file-system
enumeration order, which can de different from one run in a CI
environment from one other.  As a result, when adding/removing a single
entry, the whole file can be rearranged, leading to unexpectedly large
changes.

In order to minimize these changes and make them easier to audit, sort
the list of file before aggregating them.
