### PR TITLE
Add support for adding/removing other members on the map

### DIFF
--- a/.github/workflows/add_me_to_the_map.yml
+++ b/.github/workflows/add_me_to_the_map.yml
@@ -1,10 +1,14 @@
 ---
 name: Add me to the map
-run-name: 'Add ${{ github.triggering_actor }} to the map'
+run-name: 'Add ${{ github.event.inputs.user || github.triggering_actor }} to the map'
 
 on:
   workflow_dispatch:
     inputs:
+      user:
+        description: 'GitHub login of the user to add to the map (yourself when empty)'
+        required: false
+        type: string
       location:
         description: 'Location / Address (read from user profile when empty)'
         required: false
@@ -32,7 +36,7 @@ jobs:
           ref: 'gh-pages'
       - name: Add user location
         run: |
-          ./.github/actions/add-user-location ${{ github.triggering_actor }}
+          ./.github/actions/add-user-location ${{ github.event.inputs.user || github.triggering_actor }}
         env:
           INPUT_LATITUDE: ${{ github.event.inputs.latitude }}
           INPUT_LONGITUDE: ${{ github.event.inputs.longitude }}
@@ -43,4 +47,4 @@ jobs:
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: "Add ${{ github.triggering_actor }} to the map"
+          commit_message: "Add ${{ github.event.inputs.user || github.triggering_actor }} to the map"

--- a/.github/workflows/remove_me_from_the_map.yml
+++ b/.github/workflows/remove_me_from_the_map.yml
@@ -1,9 +1,14 @@
 ---
 name: Remove me from the map
-run-name: 'Remove ${{ github.triggering_actor }} from the map'
+run-name: 'Remove ${{ github.event.inputs.user || github.triggering_actor }} from the map'
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      user:
+        description: 'GitHub login of the user to remove from the map (yourself when empty)'
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -19,10 +24,10 @@ jobs:
           ref: 'gh-pages'
       - name: Remove user location
         run: |
-         rm -f _data/${{ github.triggering_actor }}.json
+         rm -f _data/${{ github.event.inputs.user || github.triggering_actor }}.json
       - name: Aggregate all users locations
         uses: ./.github/actions/aggregate-members-location
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: "Remove ${{ github.triggering_actor }} from the map"
+          commit_message: "Remove ${{ github.event.inputs.user || github.triggering_actor }} from the map"


### PR DESCRIPTION
We currently require users to have write access to the repository in
order add/remove them from the map on self-service.  In many case, this
is not ideal (e.g. contributors may have limited access to the
repository, former members cannot remove them) so add a field to allow
providing the login of the user to add or remove.

This still allow self-servicing for users with write access, but allow
these users to easily manage entries of other contributor without such
access.
